### PR TITLE
Chat dropdown

### DIFF
--- a/src/app/[[...page]]/page.tsx
+++ b/src/app/[[...page]]/page.tsx
@@ -255,7 +255,7 @@ export default function Home({ params }: { params: { page: string[] } }) {
         <MultiChat
           channels={order}
           activeChat={activeChat}
-          updateActiveChat={setActiveChat}
+          setActiveChat={setActiveChat}
         />
       </main>
     </div>

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -55,13 +55,9 @@ const MultiChat = ({
         >
           <ArrowLeft />
         </div>
-        <span
-          className={`${
-            open ? 'block' : 'hidden'
-          } uppercase font-bold text-sm text-center`}
-        >
-          {activeChat}
-        </span>
+        <div className={`${open ? 'block' : 'hidden'}`}>
+          <ChatDropdown channels={channels} activeChat={activeChat} />
+        </div>
         <div
           onClick={next}
           className={`${
@@ -104,6 +100,32 @@ const Chat = ({ channel, visible }: { channel: string; visible: boolean }) => {
       ></iframe>
     </div>
   );
+};
+
+const ChatDropdown = ({
+  channels,
+  activeChat,
+}: {
+  channels: string[];
+  activeChat: string;
+}) => {
+  if (channels.length > 0) {
+    return (
+      <select className="uppercase font-bold text-sm text-center bg-chatpanel">
+        {channels.map((e, i) => (
+          <option value={e} selected={e == activeChat} key={i}>
+            {e}
+          </option>
+        ))}
+      </select>
+    );
+  } else {
+    return (
+      <span className="uppercase font-bold text-sm text-center">
+        No Channels
+      </span>
+    );
+  }
 };
 
 export default MultiChat;

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -13,11 +13,11 @@ const EMBED_PARENT = process.env.NEXT_PUBLIC_TWITCH_EMBED_PARENT;
 const MultiChat = ({
   channels,
   activeChat,
-  updateActiveChat,
+  setActiveChat,
 }: {
   channels: string[];
   activeChat: string;
-  updateActiveChat: (chat: string) => void;
+  setActiveChat: (chat: string) => void;
 }) => {
   const [visibleIndex, setVisibleIndex] = useState(0);
 
@@ -29,19 +29,19 @@ const MultiChat = ({
     var i = visibleIndex + 1;
     if (i > channels.length - 1) i = 0;
     setVisibleIndex(i);
-    updateActiveChat(channels[i]);
+    setActiveChat(channels[i]);
   };
 
   const prev = () => {
     var i = visibleIndex - 1;
     if (i < 0) i = channels.length - 1;
     setVisibleIndex(i);
-    updateActiveChat(channels[i]);
+    setActiveChat(channels[i]);
   };
 
   const dropdownSelected = (chat: string) => {
     setVisibleIndex(channels.findIndex((e) => e == chat));
-    updateActiveChat(chat);
+    setActiveChat(chat);
   };
 
   let [open, setOpen] = useState<boolean>(true);
@@ -53,18 +53,20 @@ const MultiChat = ({
     <div className={`flex flex-col h-full ${open ? 'w-[350px]' : 'w-auto'}`}>
       <div className="relative flex h-[50px] flex-wrap bg-chatpanel border-b border-twborder text-twtext items-center justify-between">
         <div
-          onClick={prev}
-          className={`${
-            open ? 'block' : 'hidden'
-          } h-[20px] px-2 cursor-pointer select-none hover:bg-twbuttonbg hover:bg-opacity-[0.48]`}
+          className={`${!open ? 'absolute left-[-30px] top-4 z-10' : 'ml-2'} `}
         >
-          <ArrowLeft />
+          <button
+            onClick={toggleOpen}
+            className="inline-flex h-[30px] p-2 hover:bg-twbuttonbg hover:bg-opacity-[0.48] rounded-[4px]"
+          >
+            {open ? <CollapseRight /> : <CollapseLeft />}
+          </button>
         </div>
         <div className={`${open ? 'block' : 'hidden'}`}>
           <ChatDropdown
             channels={channels}
             activeChat={activeChat}
-            updateActiveChat={dropdownSelected}
+            setActiveChat={dropdownSelected}
           />
         </div>
         <div
@@ -74,18 +76,6 @@ const MultiChat = ({
           } h-[20px] px-2 cursor-pointer select-none hover:bg-twbuttonbg hover:bg-opacity-[0.48]`}
         >
           <ArrowRight />
-        </div>
-        <div
-          className={`${
-            open ? 'left-2' : 'left-[-30px]'
-          } absolute bottom-[-3em] z-10`}
-        >
-          <button
-            onClick={toggleOpen}
-            className="inline-flex h-[30px] p-2 hover:bg-twbuttonbg hover:bg-opacity-[0.48] rounded-[4px]"
-          >
-            {open ? <CollapseRight /> : <CollapseLeft />}
-          </button>
         </div>
       </div>
       <div className={`${open ? 'block' : 'hidden'} flex grow h-auto`}>
@@ -114,17 +104,17 @@ const Chat = ({ channel, visible }: { channel: string; visible: boolean }) => {
 const ChatDropdown = ({
   channels,
   activeChat,
-  updateActiveChat,
+  setActiveChat,
 }: {
   channels: string[];
   activeChat: string;
-  updateActiveChat: (chat: string) => void;
+  setActiveChat: (chat: string) => void;
 }) => {
   if (channels.length > 0) {
     return (
       <select
         className="uppercase font-bold text-sm text-center bg-chatpanel"
-        onChange={(e) => updateActiveChat(e.target.value)}
+        onChange={(e) => setActiveChat(e.target.value)}
       >
         {channels.map((e, i) => (
           <option value={e} selected={e == activeChat} key={i}>

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -39,6 +39,11 @@ const MultiChat = ({
     updateActiveChat(channels[i]);
   };
 
+  const dropdownSelected = (chat: string) => {
+    setVisibleIndex(channels.findIndex((e) => e == chat));
+    updateActiveChat(chat);
+  };
+
   let [open, setOpen] = useState<boolean>(true);
   const toggleOpen = () => {
     setOpen(!open);
@@ -56,7 +61,11 @@ const MultiChat = ({
           <ArrowLeft />
         </div>
         <div className={`${open ? 'block' : 'hidden'}`}>
-          <ChatDropdown channels={channels} activeChat={activeChat} />
+          <ChatDropdown
+            channels={channels}
+            activeChat={activeChat}
+            updateActiveChat={dropdownSelected}
+          />
         </div>
         <div
           onClick={next}
@@ -105,13 +114,18 @@ const Chat = ({ channel, visible }: { channel: string; visible: boolean }) => {
 const ChatDropdown = ({
   channels,
   activeChat,
+  updateActiveChat,
 }: {
   channels: string[];
   activeChat: string;
+  updateActiveChat: (chat: string) => void;
 }) => {
   if (channels.length > 0) {
     return (
-      <select className="uppercase font-bold text-sm text-center bg-chatpanel">
+      <select
+        className="uppercase font-bold text-sm text-center bg-chatpanel"
+        onChange={(e) => updateActiveChat(e.target.value)}
+      >
         {channels.map((e, i) => (
           <option value={e} selected={e == activeChat} key={i}>
             {e}

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -62,7 +62,7 @@ const MultiChat = ({
             {open ? <CollapseRight /> : <CollapseLeft />}
           </button>
         </div>
-        <div className={`${open ? 'block' : 'hidden'}`}>
+        <div className={`flex flex-col grow px-2 ${open ? 'block' : 'hidden'}`}>
           <ChatDropdown
             channels={channels}
             activeChat={activeChat}
@@ -113,7 +113,7 @@ const ChatDropdown = ({
   if (channels.length > 0) {
     return (
       <select
-        className="uppercase font-bold text-sm text-center bg-chatpanel"
+        className="uppercase font-bold text-sm text-center bg-chatpanel focus:outline-0 py-4"
         onChange={(e) => setActiveChat(e.target.value)}
       >
         {channels.map((e, i) => (


### PR DESCRIPTION
change chat header from previous and next buttons to a dropdown (although the next button is still there).

also moves the collapse button to the chat header, instead of floating over the chat iframe, which caused a "Chatting is disabled for channel owner/mods because the Twitch Chat window is obscured by another element" warning that temporarily disabled chatting. this change also fixes that bug.